### PR TITLE
Handle empty structs specifically

### DIFF
--- a/encdec_test.go
+++ b/encdec_test.go
@@ -30,6 +30,9 @@ type TestStruct struct {
 	SS   []string // max:1024
 }
 
+type EmptyStruct struct {
+}
+
 type Opaque [32]byte
 
 func (u *Opaque) EncodeXDRInto(w *xdr.Writer) (int, error) {

--- a/encdec_xdr_test.go
+++ b/encdec_xdr_test.go
@@ -183,3 +183,46 @@ func (o *TestStruct) DecodeXDRFrom(xr *xdr.Reader) error {
 	}
 	return xr.Error()
 }
+
+/*
+
+EmptyStruct Structure:
+(contains no fields)
+
+
+struct EmptyStruct {
+}
+
+*/
+
+func (o EmptyStruct) EncodeXDR(w io.Writer) (int, error) {
+	return 0, nil
+}
+
+func (o EmptyStruct) MarshalXDR() ([]byte, error) {
+	return nil, nil
+}
+
+func (o EmptyStruct) MustMarshalXDR() []byte {
+	return nil
+}
+
+func (o EmptyStruct) AppendXDR(bs []byte) ([]byte, error) {
+	return bs, nil
+}
+
+func (o EmptyStruct) EncodeXDRInto(xw *xdr.Writer) (int, error) {
+	return xw.Tot(), xw.Error()
+}
+
+func (o *EmptyStruct) DecodeXDR(r io.Reader) error {
+	return nil
+}
+
+func (o *EmptyStruct) UnmarshalXDR(bs []byte) error {
+	return nil
+}
+
+func (o *EmptyStruct) DecodeXDRFrom(xr *xdr.Reader) error {
+	return xr.Error()
+}


### PR DESCRIPTION
Makes the generated code for empty structs look a bit less stupid, which is nice as we actually have those a bit all over the place. Contains an example of that too.

@AudriusButkevicius wanna have a look-see?