### PR TITLE
fix: correctly handle missing padding bytes

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -62,7 +62,7 @@ func (u *Unmarshaller) UnmarshalBytesMax(max int) []byte {
 		u.Error = ElementSizeExceeded("bytes field", l, max)
 		return nil
 	}
-	if len(u.Data) < l+4 {
+	if len(u.Data) < 4+l+Padding(l) {
 		u.Error = io.ErrUnexpectedEOF
 		return nil
 	}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,0 +1,17 @@
+package xdr
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestMissingPaddingUnmarshal(t *testing.T) {
+	// A three-byte byte slice, missing the fourth padding byte
+	v := []byte{0x00, 0x00, 0x00, 0x03, 0xCA, 0xFE, 0xFE}
+	u := &Unmarshaller{Data: v}
+	u.UnmarshalBytesMax(4)
+	if !errors.Is(u.Error, io.ErrUnexpectedEOF) {
+		t.Fatal(`Expected "Unexpected EOF", got`, u.Error)
+	}
+}


### PR DESCRIPTION
Check that the slice is long enough to contain the required padding before slicing.